### PR TITLE
Fixes for build on Darwin

### DIFF
--- a/qtiplot/src/analysis/dialogs/FitDialog.cpp
+++ b/qtiplot/src/analysis/dialogs/FitDialog.cpp
@@ -1023,11 +1023,11 @@ void FitDialog::showFitPage()
 	int prec = boxPrecision->value();
     for (int i = 0; i<parameters; i++){
         QTableWidgetItem *it = new QTableWidgetItem(paramList[i]);
-#ifdef Q_CC_MSVC
+    #if defined(Q_CC_MSVC) || defined(__APPLE__)
         it->setFlags(it->flags() & (~Qt::ItemIsEditable));
-#else
+    #else
         it->setFlags(!Qt::ItemIsEditable);
-#endif
+    #endif
         it->setBackground(QBrush(Qt::lightGray));
         it->setForeground(Qt::black);
         QFont font = it->font();
@@ -1053,7 +1053,11 @@ void FitDialog::showFitPage()
         boxParams->setCellWidget(i, 2, sb);
 
         it = new QTableWidgetItem();
-		it->setFlags(!Qt::ItemIsEditable);
+    #if defined(Q_CC_MSVC) || defined(__APPLE__)
+        it->setFlags(it->flags() & (~Qt::ItemIsEditable));
+    #else
+        it->setFlags(!Qt::ItemIsEditable);
+    #endif
 		it->setText("--");
 		boxParams->setItem(i, 5, it);
 	}
@@ -1065,11 +1069,11 @@ void FitDialog::showFitPage()
         boxParams->showColumn(4);
 		for (int i = 0; i<boxParams->rowCount(); i++ ){
             QTableWidgetItem *it = new QTableWidgetItem();
-#ifdef Q_CC_MSVC
+		#if defined(Q_CC_MSVC) || defined(__APPLE__)
             it->setFlags(it->flags() & (~Qt::ItemIsEditable));
-#else
+		#else
             it->setFlags(!Qt::ItemIsEditable);
-#endif
+		#endif
             it->setBackground(QBrush(Qt::lightGray));
             boxParams->setItem(i, 4, it);
 

--- a/qtiplot/src/core/ConfigDialog.cpp
+++ b/qtiplot/src/core/ConfigDialog.cpp
@@ -1444,7 +1444,11 @@ void ConfigDialog::setColorsList(const QList<QColor>& colList, const QStringList
 	colorsList->setRowCount(colors);
 	for (int i = 0; i < colors; i++){
 		QTableWidgetItem *it = new QTableWidgetItem();
+	#if defined(Q_CC_MSVC) || defined(__APPLE__)
+		it->setFlags(it->flags() & (~Qt::ItemIsEditable));
+	#else
 		it->setFlags(!Qt::ItemIsEditable);
+	#endif
 		it->setBackground(QBrush(colList[i]));
 		colorsList->setItem(i, 0, it);
 

--- a/qtiplot/src/lib/src/ColorMapEditor.cpp
+++ b/qtiplot/src/lib/src/ColorMapEditor.cpp
@@ -155,7 +155,7 @@ void ColorMapEditor::setColorMap(const LinearColorMap& map)
 		QColor c = color_map.color(i);
 
 		QTableWidgetItem *it = new QTableWidgetItem(c.name());
-	#ifdef Q_CC_MSVC
+	#if defined(Q_CC_MSVC) || defined(__APPLE__)
 		it->setFlags(it->flags() & (~Qt::ItemIsEditable));
 	#else
 		it->setFlags(!Qt::ItemIsEditable);
@@ -246,7 +246,7 @@ void ColorMapEditor::insertLevel()
     table->setCellWidget(row, 0, sb);
 
 	QTableWidgetItem *it = new QTableWidgetItem(c.name());
-#ifdef Q_CC_MSVC
+#if defined(Q_CC_MSVC) || defined(__APPLE__)
 	it->setFlags(it->flags() & (~Qt::ItemIsEditable));
 #else
 	it->setFlags(!Qt::ItemIsEditable);

--- a/qtiplot/src/matrix/MatrixValuesDialog.cpp
+++ b/qtiplot/src/matrix/MatrixValuesDialog.cpp
@@ -72,7 +72,8 @@ MatrixValuesDialog::MatrixValuesDialog( ScriptingEnv *env, QWidget* parent, Qt::
 	gl1->setColumnStretch(1, 1);
 	gl1->setColumnStretch(3, 1);
 
-	functions = new QComboBox(false);
+	functions = new QComboBox();
+	functions->setEditable(false);
 	functions->addItems(scriptEnv->mathFunctions());
 	btnAddFunction = new QPushButton(tr( "Add &Function" ));
 	btnAddCell = new QPushButton(tr( "Add Ce&ll" ));

--- a/qtiplot/src/plot2D/dialogs/LayerDialog.cpp
+++ b/qtiplot/src/plot2D/dialogs/LayerDialog.cpp
@@ -69,14 +69,16 @@ multi_layer(NULL)
 	QGridLayout *gl2 = new QGridLayout(gb2);
 	gl2->addWidget(new QLabel(tr("Horizontal")), 0, 0);
 
-	alignHorBox = new QComboBox( false );
+	alignHorBox = new QComboBox();
+	alignHorBox->setEditable(false);
 	alignHorBox->insertItem( tr( "Center" ) );
 	alignHorBox->insertItem( tr( "Left" ) );
 	alignHorBox->insertItem( tr( "Right" ) );
 	gl2->addWidget(alignHorBox, 0, 1);
 
 	gl2->addWidget(new QLabel( tr( "Vertical" )), 1, 0 );
-	alignVertBox = new QComboBox( false );
+	alignVertBox = new QComboBox();
+	alignVertBox->setEditable(false);
 	alignVertBox->insertItem( tr( "Center" ) );
 	alignVertBox->insertItem( tr( "Top" ) );
 	alignVertBox->insertItem( tr( "Bottom" ) );

--- a/qtiplot/src/plot2D/dialogs/PlotDialog.cpp
+++ b/qtiplot/src/plot2D/dialogs/PlotDialog.cpp
@@ -958,7 +958,8 @@ void PlotDialog::initPiePage()
 	l4->setBuddy(boxFirstColor);
 	gl2->addWidget(l4, 0, 0);
 
-	boxPiePattern = new PatternBox(false);
+	boxPiePattern = new PatternBox();
+	boxPiePattern->setEditable(false);
 	gl2->addWidget(boxPiePattern, 1, 1);
 	gl2->setRowStretch(2, 1);
 
@@ -1341,7 +1342,8 @@ void PlotDialog::initLinePage()
 	hb->addWidget(boxCurveOpacity);
 	gl2->addLayout(hb, 1, 1);
 
-	boxPattern = new PatternBox(false);
+	boxPattern = new PatternBox();
+	boxPattern->setEditable(false);
 	gl2->addWidget(boxPattern, 2, 1);
 	
 	QLabel *l6 = new QLabel("&" + tr("Pattern"));
@@ -2130,17 +2132,20 @@ void PlotDialog::initVectPage()
     QGridLayout *gl3 = new QGridLayout(GroupBoxVectEnd);
     labelXEnd = new QLabel(tr( "X End" ));
     gl3->addWidget(labelXEnd, 0, 0);
-	xEndBox = new QComboBox(false);
+	xEndBox = new QComboBox();
+	xEndBox->setEditable(false);
     gl3->addWidget(xEndBox, 0, 1);
 
 	labelYEnd = new QLabel(tr( "Y End" ));
     gl3->addWidget(labelYEnd, 1, 0);
-	yEndBox = new  QComboBox( false);
+	yEndBox = new QComboBox();
+	yEndBox->setEditable(false);
     gl3->addWidget(yEndBox, 1, 1);
 
 	labelPosition = new QLabel(tr( "Position" ));
     gl3->addWidget(labelPosition, 2, 0);
-	vectPosBox = new  QComboBox( false);
+	vectPosBox = new  QComboBox();
+	vectPosBox->setEditable(false);
 	vectPosBox->addItem(tr("Tail"));
 	vectPosBox->addItem(tr("Middle"));
 	vectPosBox->addItem(tr("Head"));

--- a/qtiplot/src/table/SetColValuesDialog.cpp
+++ b/qtiplot/src/table/SetColValuesDialog.cpp
@@ -72,12 +72,14 @@ SetColValuesDialog::SetColValuesDialog( ScriptingEnv *env, QWidget* parent, Qt::
 	hbox1->addWidget(end);
 
 	QGridLayout *gl1 = new QGridLayout();
-	functions = new QComboBox(false);
+	functions = new QComboBox();
+	functions->setEditable(false);
 	functions->addItems(muParserScripting::functionsList(true));
 	gl1->addWidget(functions, 0, 0);
 	btnAddFunction = new QPushButton(tr( "Add function" ));
 	gl1->addWidget(btnAddFunction, 0, 1);
-	boxColumn = new QComboBox(false);
+	boxColumn = new QComboBox();
+	boxColumn->setEditable(false);
 	gl1->addWidget(boxColumn, 1, 0);
 	btnAddCol = new QPushButton(tr( "Add column" ));
 	gl1->addWidget(btnAddCol, 1, 1);

--- a/qtiplot/src/table/TableDialog.cpp
+++ b/qtiplot/src/table/TableDialog.cpp
@@ -136,7 +136,8 @@ TableDialog::TableDialog(Table *t, QWidget* parent, Qt::WFlags fl )
     labelFormat = new QLabel(tr( "Format:" ));
  	gl1->addWidget(labelFormat, 2, 0);
 
-    formatBox = new QComboBox(false);
+    formatBox = new QComboBox();
+    formatBox->setEditable(false);
     gl1->addWidget(formatBox, 2, 1);
 
 	labelNumeric = new QLabel(tr( "Precision:" ));


### PR DESCRIPTION
This PR fixes a build on Darwin (tested with `gcc12`). It addresses two errors:

1. Wrong specification for `PatternBox` and `QComboBox`:
```
error: no matching function for call to 'QComboBox::QComboBox(bool)'
error: no matching function for call to 'PatternBox::PatternBox(bool)'
```
2. Error on MacOS with regard to `ItemIsEditable` flag:
```
error: cannot convert 'bool' to 'Qt::ItemFlags'
```